### PR TITLE
feat: ci improvements

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -18,9 +18,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: actions/checkout@v3
 
@@ -54,9 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name != 'release'
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - run: npm ci
+      - run: npm ci --no-fund --prefer-offline --no-audit
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - run: npm ci
+      - run: npm ci --no-fund --prefer-offline --no-audit
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -99,7 +99,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@significa'
 
-      - run: npm ci
+      - run: npm ci --no-fund --prefer-offline --no-audit
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- dd314d2
    Note: we still need permissions for the publish step, but not for reading other packages published in our account.
    This is managed in the setting of the package we are trying to read (install), in this case `significa-style`: https://github.com/orgs/significa/packages/npm/tsconfig-config/settings


- 935c1be
    Attempt in making npm ci faster by using more cache, and make it less verbose (adverts, etc).