### PR TITLE
fix: remove samesite attribute

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -74,7 +74,6 @@ export class ServerAuth {
     return getCookieString({
       [key]: value,
       Path: '/',
-      SameSite: 'Strict',
       Secure: true,
       ...cookie,
     })


### PR DESCRIPTION
Removes `SameSite` attribute. The cookie-sending behavior if SameSite is not specified is `SameSite=Lax`.